### PR TITLE
Support new pnpm lockfile name

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,7 +109,8 @@ async function getInstallCmd(rootPath) {
 
   if (installed('pnpm')) {
     const lockPath = join(rootPath, 'shrinkwrap.yaml');
-    if (await exists(lockPath)) return 'pnpm';
+    const lockPath2 = join(rootPath, 'pnpm-lock.yaml');
+    if (await exists(lockPath) || await exists(lockPath2)) return 'pnpm';
   }
 
   return 'npm';


### PR DESCRIPTION
PNPM has changed its lockfile name from shrinkwrap.yaml to pnpm-lock.yaml: https://github.com/pnpm/pnpm/issues/1635